### PR TITLE
Deleta agendamento e retorna vaga para horario

### DIFF
--- a/src/main/java/com/ideiaapi/service/AgendamentoService.java
+++ b/src/main/java/com/ideiaapi/service/AgendamentoService.java
@@ -115,6 +115,17 @@ public class AgendamentoService {
     }
 
     public void deletaAgendamento(Long codigo) {
+
+        Agendamento agendamento = this.agendamentoRepository.findOne(codigo);
+
+        if (agendamento == null)
+            throw new EmptyResultDataAccessException(1);
+
+        if (!agendamento.getAvulso()) {
+            Horario horario = horarioService.buscaHorario(agendamento.getCodHorario());
+            this.horarioService.devolverHorario(horario);
+        }
+
         this.agendamentoRepository.delete(codigo);
     }
 

--- a/src/main/java/com/ideiaapi/service/HorarioService.java
+++ b/src/main/java/com/ideiaapi/service/HorarioService.java
@@ -82,6 +82,12 @@ public class HorarioService {
         this.horarioRepository.save(horario);
     }
 
+    public void devolverHorario(Horario horario) {
+        int restante = horario.getRestante();
+        horario.setRestante(restante + 1);
+        this.horarioRepository.save(horario);
+    }
+
     private Horario getHorarioWithHoraExameCompleta(Agenda agenda, Horario horario) {
 
         horario.setHoraExame(horario.getHoraExame() + " - " + agenda.getDiaAgenda().getDayOfMonth() + " "

--- a/src/test/java/com/ideiaapi/service/AgendamentoServiceTest.java
+++ b/src/test/java/com/ideiaapi/service/AgendamentoServiceTest.java
@@ -1,0 +1,79 @@
+package com.ideiaapi.service;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+
+import com.ideiaapi.base.BaseTest;
+import com.ideiaapi.model.Agendamento;
+import com.ideiaapi.model.Horario;
+import com.ideiaapi.repository.AgendamentoRepository;
+
+public class AgendamentoServiceTest extends BaseTest {
+
+    @Mock
+    private AgendamentoRepository agendamentoRepository;
+
+    @Mock
+    private HorarioService horarioService;
+
+    @Mock
+    private AgendaService agendaService;
+
+    @InjectMocks
+    private AgendamentoService agendamentoService;
+
+    private Horario horario = new Horario();
+    private Agendamento agendamento = new Agendamento();
+
+    @Before
+    public void setUp() throws Exception {
+
+        horario.setHoraExame("8:00");
+        horario.setCodigo(0L);
+        horario.setDisponivel(true);
+        horario.setRestante(2);
+        horario.setAvulso(true);
+        horario.setMaximoPermitido(4);
+
+        agendamento.setCodHorario(0L);
+        agendamento.setAvulso(false);
+    }
+
+    @Test
+    public void deletaAgendamentoNaoAvulso() {
+
+        when(agendamentoRepository.findOne(1L)).thenReturn(agendamento);
+        when(horarioService.buscaHorario(agendamento.getCodHorario())).thenReturn(horario);
+
+        agendamentoService.deletaAgendamento(1L);
+
+        verify(horarioService, times(1)).devolverHorario(horario);
+        verify(agendamentoRepository, times(1)).delete(1L);
+    }
+
+    @Test
+    public void deletaAgendamentoAvulso() {
+
+        agendamento.setAvulso(true);
+
+        when(agendamentoRepository.findOne(1L)).thenReturn(agendamento);
+
+        agendamentoService.deletaAgendamento(1L);
+
+        verify(horarioService, times(0)).devolverHorario(horario);
+        verify(agendamentoRepository, times(1)).delete(1L);
+    }
+
+    @Test(expected = IncorrectResultSizeDataAccessException.class)
+    public void deletaAgendamentoError() {
+
+        agendamentoService.deletaAgendamento(1L);
+    }
+}


### PR DESCRIPTION
## Explicações

- Alteração do serviço que remove agendamento, devolvendo o horario que foi queimado para as vagas restantes (caso não seja um agendamento avulso).

- mvn clean install ok
- app subindo ok